### PR TITLE
Add zone as parameter for getting the carbon intensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ EMAPS_TOKEN: <your_token>
 The plugin requires the following inputs:
 
 * `timestamp`: Timestamp of the recorded event (2021-01-01T00:00:00Z) RFC3339
-* `longitude`: Longitude of the software system connected to a grid (12.5683).
-* `latitude`: Latitude of the software system connected to a grid (55.6761).
+* `longitude`: Longitude of the software system connected to a grid (12.5683). Required if `zone` is not provided.
+* `latitude`: Latitude of the software system connected to a grid (55.6761). Required if `zone` is not provided.
+* `zone`: Zone identifier of the grid (e.g. `PJM`). Required if `latitude` and `longitude` are not provided.
 * `duration`: Duration of the recorded event in seconds (e.g. 3600 for one hour). A single event can last at most 10 days, so the maximum value of this parameter is 864000.
 * (optional) `power_consumption`: You can provide the average power consumption in `kWh` for the duration of the event. This will allow the plugin to calulate the total emissions for the event. If this input is not provided, the plugin will calculate the average carbon intensity of the grid for the duration of the event and return the value in units of `gCO2eq`.
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -130,7 +130,7 @@ describe('lib/electricitymaps: ', () => {
           {
             timestamp: '2024-03-18T01:36:00Z',
             longitude: 12.5683,
-            latitude: 55.6761,
+            latitude: 55.6762,
             duration: 7200,
           },
         ]);
@@ -139,7 +139,7 @@ describe('lib/electricitymaps: ', () => {
           {
             carbonIntensity: 331.6,
             duration: 7200,
-            latitude: 55.6761,
+            latitude: 55.6762,
             longitude: 12.5683,
             timestamp: '2024-03-18T01:36:00Z',
             unit: 'gCO2eq',

--- a/src/lib/electricitymaps/index.ts
+++ b/src/lib/electricitymaps/index.ts
@@ -61,12 +61,20 @@ export const ElectricityMapsCarbonIntensity = (): PluginInterface => {
       const start = dayjs(input.timestamp);
       const end = start.add(input.duration, 'second');
 
-      const carbonIntensities = api.getCarbonIntensity({
-        lon: input.longitude,
-        lat: input.latitude,
-        start: start.toISOString(),
-        end: end.toISOString(),
-      });
+      const carbonIntensityParams = input.zone
+        ? {
+            zone: input.zone,
+            start: start.toISOString(),
+            end: end.toISOString(),
+          }
+        : {
+            lon: input.longitude,
+            lat: input.latitude,
+            start: start.toISOString(),
+            end: end.toISOString(),
+          };
+
+      const carbonIntensities = api.getCarbonIntensity(carbonIntensityParams);
 
       const numHours = Math.floor(input.duration / 3600);
       const blocks = [...Array(numHours).keys()];

--- a/src/lib/electricitymaps/types.ts
+++ b/src/lib/electricitymaps/types.ts
@@ -1,6 +1,7 @@
 export interface ElectricityMapsCarbonIntensityParams {
-  lat: number;
-  lon: number;
+  lat?: number;
+  lon?: number;
+  zone?: string;
   start: string;
   end: string;
 }

--- a/src/lib/util/schemas.ts
+++ b/src/lib/util/schemas.ts
@@ -27,7 +27,8 @@ export const inputSchema = z
       })
       .refine(val => !isNaN(val), {
         message: "The 'latitude' field must be a number",
-      }),
+      })
+      .optional(),
     longitude: z
       .number({
         required_error: "The 'longitude' field is required",
@@ -35,7 +36,13 @@ export const inputSchema = z
       })
       .refine(val => !isNaN(val), {
         message: "The 'longitude' field must be a number",
-      }),
+      })
+      .optional(),
+    zone: z
+      .string({
+        invalid_type_error: "The 'zone' field must be a string",
+      })
+      .optional(),
   })
   .refine(data => {
     const start = dayjs(data.timestamp);
@@ -46,4 +53,44 @@ export const inputSchema = z
         message: 'The maximum duration is 10 days for the Electricity Maps API',
       }
     );
-  });
+  })
+  .refine(
+    data => {
+      // Either zone is provided OR both latitude and longitude are provided
+      return (
+        (data.zone !== undefined &&
+          data.latitude === undefined &&
+          data.longitude === undefined) ||
+        (data.zone === undefined &&
+          data.latitude !== undefined &&
+          data.longitude !== undefined)
+      );
+    },
+    {
+      message: "The 'longitude' field is required if 'latitude' is provided",
+    }
+  )
+  .refine(
+    data => {
+      // If latitude is provided, longitude must also be provided
+      if (data.latitude !== undefined) {
+        return data.longitude !== undefined;
+      }
+      return true;
+    },
+    {
+      message: "The 'longitude' field is required if 'latitude' is provided",
+    }
+  )
+  .refine(
+    data => {
+      // If longitude is provided, latitude must also be provided
+      if (data.longitude !== undefined) {
+        return data.latitude !== undefined;
+      }
+      return true;
+    },
+    {
+      message: "The 'latitude' field is required if 'longitude' is provided",
+    }
+  );

--- a/src/lib/util/schemas.ts
+++ b/src/lib/util/schemas.ts
@@ -56,22 +56,6 @@ export const inputSchema = z
   })
   .refine(
     data => {
-      // Either zone is provided OR both latitude and longitude are provided
-      return (
-        (data.zone !== undefined &&
-          data.latitude === undefined &&
-          data.longitude === undefined) ||
-        (data.zone === undefined &&
-          data.latitude !== undefined &&
-          data.longitude !== undefined)
-      );
-    },
-    {
-      message: "The 'longitude' field is required if 'latitude' is provided",
-    }
-  )
-  .refine(
-    data => {
       // If latitude is provided, longitude must also be provided
       if (data.latitude !== undefined) {
         return data.longitude !== undefined;
@@ -92,5 +76,22 @@ export const inputSchema = z
     },
     {
       message: "The 'latitude' field is required if 'longitude' is provided",
+    }
+  )
+  .refine(
+    data => {
+      // Either zone is provided OR both latitude and longitude are provided
+      return (
+        (data.zone !== undefined &&
+          data.latitude === undefined &&
+          data.longitude === undefined) ||
+        (data.zone === undefined &&
+          data.latitude !== undefined &&
+          data.longitude !== undefined)
+      );
+    },
+    {
+      message:
+        "Either the 'zone' field OR both 'longitude' and 'latitude' fields must be provided",
     }
   );


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- This PR adds the ability for a user of the electricity maps IF plugin to get the carbon intensity by zone instead of by latitude and longitude. The schema has been modified so that either the zone OR longitude/latitude can be passed in.


<!-- Make sure tests and lint pass on CI. -->

